### PR TITLE
Add HELLSBELLS token metadata

### DIFF
--- a/hellsbells_metadata.json
+++ b/hellsbells_metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Hellsbells",
+  "symbol": "HELLSBELLS",
+  "uri": "https://raw.githubusercontent.com/bonzocrypt/hellsbells/main/images/hellsbells_logo.png",
+  "seller_fee_basis_points": 0,
+  "creators": null
+}

--- a/hellsbells_metadata.json
+++ b/hellsbells_metadata.json
@@ -1,7 +1,19 @@
 {
-  "name": "Hellsbells",
+  "name": "HELLSBELLS BONZ Coin",
   "symbol": "HELLSBELLS",
-  "uri": "https://raw.githubusercontent.com/bonzocrypt/hellsbells/main/images/hellsbells_logo.png",
-  "seller_fee_basis_points": 0,
-  "creators": null
+  "description": "The official token for HELLSBELLS MEME Coin. A Solana-based memecoin destined to rock the charts.",
+  "image": "https://raw.githubusercontent.com/bonzocrypt/eventpricing.github.io/main/images/hellsbellslogo.jpg",
+  "extensions": {
+    "website": "https://bonzcoin.io",
+    "twitter": "https://twitter.com/bonzocrypt"
+  },
+  "properties": {
+    "category": "token",
+    "creators": [
+      {
+        "address": "91Fvqpbz5LCtjWVr7cab8FVPtvMhRQVtxRDGy5DTqrGS",
+        "share": 100
+      }
+    ]
+  }
 }


### PR DESCRIPTION
This pull request adds metadata for HELLSBELLS (symbol: HELLSBELLS), a utility music token built on Solana.

- Token address: LWSkayM12jCUFtRTQn3yQtN7NJUSynsGjGiT4Spk9wy
- Metadata file: hellsbells_metadata.json
- Hosted image: https://raw.githubusercontent.com/bonzocrypt/hellsbells/main/images/hellsbells_logo.png
- Includes standard name, symbol, image, and extensions
